### PR TITLE
If-none-match etag requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,11 @@ curl http://localhost:8080/subscriptions/YOUR_SUBSCRIPTION_ID/items | json_pp
 ![Feed items JSON](feeditems.png)
 
 
+# Local development
+
+Maven build.
+
+```
+docker-compose -f docker/docker-compose.yml up
+mvn clean install
+```

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <jackson.version>2.11.2</jackson.version>
         <spymemcached.version>2.11.2</spymemcached.version>
-        <kotlin.version>1.4.10</kotlin.version>
+        <kotlin.version>1.5.31</kotlin.version>
     </properties>
 
     <repositories>
@@ -183,12 +183,12 @@
         <dependency>
             <groupId>com.github.kittinunf.fuel</groupId>
             <artifactId>fuel</artifactId>
-            <version>2.2.3</version>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.kittinunf.result</groupId>
             <artifactId>result</artifactId>
-            <version>2.2.0</version>
+            <version>3.1.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/http/HttpFetcher.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/http/HttpFetcher.kt
@@ -29,10 +29,13 @@ class HttpFetcher(val userAgent: String, val timeout: Int) {
         }
     }
 
-    fun getBytes(url: String): Result<HttpResult, FuelError> {
-        val (_, response, result) = url.httpGet().
-        timeout(timeout).header("User-Agent", userAgent).response()
+    fun getBytes(url: String, etag: String?): Result<HttpResult, FuelError> {
+        val request = url.httpGet().timeout(timeout).header("User-Agent", userAgent)
+        etag?.let { etag ->
+            request.header("If-None-Match", etag)
+        }
 
+        val (_, response, result) = request.response()
         result.fold({ bytes ->
             val httpResult = HttpResult(bytes = bytes, status = response.statusCode, headers = response.headers)
             return Result.success(httpResult)

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/FeedFetcher.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/FeedFetcher.kt
@@ -26,7 +26,7 @@ class FeedFetcher @Autowired constructor(private val httpFetcher: HttpFetcher,
     private val rssFetchedBytesCounter = meterRegistry.counter("rss_fetched_bytes")
 
     fun fetchFeed(subscription: RssSubscription): Result<FetchedFeed, FeedFetchingException> {
-        loadSyndFeedWithFeedFetcher(subscription.url).fold({ syndFeedAndHttpResult ->
+        loadSyndFeedWithFeedFetcher(subscription.url, subscription.etag).fold({ syndFeedAndHttpResult ->
             val syndFeed = syndFeedAndHttpResult.first
             val httpResult = syndFeedAndHttpResult.second
 
@@ -41,11 +41,11 @@ class FeedFetcher @Autowired constructor(private val httpFetcher: HttpFetcher,
         })
     }
 
-    private fun loadSyndFeedWithFeedFetcher(feedUrl: String): Result<Pair<SyndFeed, HttpResult>, FeedFetchingException> {
+    private fun loadSyndFeedWithFeedFetcher(feedUrl: String, etag: String?): Result<Pair<SyndFeed, HttpResult>, FeedFetchingException> {
         log.info("Loading SyndFeed from url: " + feedUrl)
         rssFetchesCounter.increment()
 
-        httpFetcher.getBytes(feedUrl).fold({ httpResult ->
+        httpFetcher.getBytes(feedUrl, etag).fold({ httpResult ->
             val fetchedBytes = httpResult.bytes
             rssFetchedBytesCounter.increment(fetchedBytes.size.toDouble())
 
@@ -54,12 +54,22 @@ class FeedFetcher @Autowired constructor(private val httpFetcher: HttpFetcher,
                     Result.success(Pair(syndFeed, httpResult))
                 }, { ex ->
                     log.warn("Feed parsing error: " + ex.message)
-                    Result.error(FeedFetchingException(message = ex.message!!, httpStatus = httpResult.status, rootCause = ex))
+                    Result.error(
+                        FeedFetchingException(
+                            message = ex.message!!,
+                            httpStatus = httpResult.status,
+                            rootCause = ex
+                        )
+                    )
                 })
+
+            }  else if (httpResult.status == 304) {
+                // Not modified
+                log.info("Feed url responded with 304 not modified: " + feedUrl)
+               return Result.Failure(FeedFetchingException(message = "Feed not modified", httpResult.status))  // TODO what to return in this case
 
             } else {
                 return Result.Failure(FeedFetchingException(message = "Could not fetch feed", httpResult.status))
-
             }
 
         }, { fuelError ->


### PR DESCRIPTION
Including etags on the If-None-Match header of our GET requests is a better approach then making a preflight HEAD request.