### PR TITLE
Feed items dates are optional

### DIFF
--- a/src/main/java/uk/co/eelpieconsulting/feedlistener/twitter/TwitterFeedItemMapper.java
+++ b/src/main/java/uk/co/eelpieconsulting/feedlistener/twitter/TwitterFeedItemMapper.java
@@ -14,7 +14,7 @@ public class TwitterFeedItemMapper {
         final uk.co.eelpieconsulting.feedlistener.model.Place place = extractLocationFrom(status);
         final String mediaUrl = extractImageUrl(status);
         final String author = extractAuthorFrom(status);
-        return new FeedItem(extractHeadingFrom(status), extractUrlFrom(status), null, status.getCreatedAt(), place, mediaUrl,
+        return new FeedItem(extractHeadingFrom(status), extractUrlFrom(status), null, status.getCreatedAt(), null, place, mediaUrl,
                 author, subscription.getId(), subscription.getChannelId(), null);
     }
 

--- a/src/main/java/uk/co/eelpieconsulting/feedlistener/twitter/TwitterStatusListener.java
+++ b/src/main/java/uk/co/eelpieconsulting/feedlistener/twitter/TwitterStatusListener.java
@@ -2,6 +2,7 @@ package uk.co.eelpieconsulting.feedlistener.twitter;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.joda.time.DateTime;
 import twitter4j.StallWarning;
 import twitter4j.Status;
 import twitter4j.StatusDeletionNotice;
@@ -41,6 +42,7 @@ public class TwitterStatusListener implements StatusListener {
             final FeedItem tweetFeedItem = twitterFeedItemMapper.createFeedItemFrom(status, subscription);
             tweetFeedItem.setSubscriptionId(subscription.getId());    // TODO should we be duplicating tweets like this?
             tweetFeedItem.setChannelId(subscription.getChannelId());
+            tweetFeedItem.setAccepted(DateTime.now().toDate());
             subscription.setLatestItemDate(status.getCreatedAt());
             subscriptionsDAO.save(subscription);
 

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/controllers/FeedItemPopulator.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/controllers/FeedItemPopulator.kt
@@ -38,6 +38,7 @@ class FeedItemPopulator @Autowired constructor(val subscriptionLabelService: Sub
                 feedItem.url,
                 StringEscapeUtils.unescapeHtml(feedItem.body),
                 feedItem.date,
+                feedItem.accepted,
                 feedItem.place,
                 feedItem.imageUrl,
                 feedItem.author,

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/FeedItem.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/FeedItem.kt
@@ -26,9 +26,9 @@ class FeedItem : RssFeedable {
 
     var body: String? = null
 
-    private lateinit var date: Date
+    private var date: Date? = null
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
-    override fun getDate(): Date {
+    override fun getDate(): Date? {
         return date
     }
 
@@ -65,7 +65,7 @@ class FeedItem : RssFeedable {
     constructor(title: String?,
                 url: String,
                 body: String?,
-                date: Date,
+                date: Date?,
                 place: Place? = null,
                 imageUrl: String? = null,
                 author: String? = null,

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/FeedItem.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/FeedItem.kt
@@ -32,6 +32,9 @@ class FeedItem : RssFeedable {
         return date
     }
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+    var accepted: Date? = null
+
     var place: Place? = null
 
     private var imageUrl: String? = null
@@ -66,6 +69,7 @@ class FeedItem : RssFeedable {
                 url: String,
                 body: String?,
                 date: Date?,
+                accepted: Date? = null,
                 place: Place? = null,
                 imageUrl: String? = null,
                 author: String? = null,
@@ -77,6 +81,7 @@ class FeedItem : RssFeedable {
         this.url = url
         this.body = body
         this.date = date
+        this.accepted = accepted
         this.place = place
         this.imageUrl = imageUrl
         this.author = author

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssFeedItemMapper.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssFeedItemMapper.kt
@@ -45,6 +45,7 @@ class RssFeedItemMapper @Autowired constructor(private val rssFeedItemImageExtra
                 url,
                 body,
                 date,
+                null,
                 place,
                 imageUrl,
                 syndEntry.author,

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssFeedItemMapper.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssFeedItemMapper.kt
@@ -39,7 +39,7 @@ class RssFeedItemMapper @Autowired constructor(private val rssFeedItemImageExtra
             }
         }
 
-        if (url != null && date != null) {
+        if (url != null) {
             return FeedItem(
                 syndEntry.title,
                 url,
@@ -52,8 +52,9 @@ class RssFeedItemMapper @Autowired constructor(private val rssFeedItemImageExtra
                 subscription.channelId,
                 categories
             )
+
         } else {
-            log.warn("Saw syndEntry with no url or date: $syndEntry")
+            log.warn("Saw and ignored a syndEntry with no url: $syndEntry")
             return null
         }
     }

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssPoller.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssPoller.kt
@@ -112,7 +112,7 @@ class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO, v
                             maybeFetchedFeed?.let { fetchedFeed ->
                                 // Your fetch returned a feed. This indicates the feed has been updated or
                                 // the feed server didn't support our last modified or etag headers
-                                log.info("Fetched feed: " + fetchedFeed.feedName)
+                                log.info("Fetched feed: " + fetchedFeed.feedName + " with " + fetchedFeed.feedItems.size  + " feed items")
                                 persistFeedItems(fetchedFeed.feedItems)
 
                                 // TODO needs to be a common concern with all subscriptions types; ie Twitter etc
@@ -188,6 +188,6 @@ class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO, v
 class FeedItemLatestDateFinder {
     fun getLatestItemDate(feedItems: List<FeedItem>): Date? {
         // Map to dates; return max
-        return feedItems.map { it.date }.stream().max(Date::compareTo).orElse(null)
+        return feedItems.map { it.date }.filterNotNull().stream().max(Date::compareTo).orElse(null)
     }
 }

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssPoller.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssPoller.kt
@@ -172,6 +172,7 @@ class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO, v
         private fun persistFeedItems(feedItems: List<FeedItem>) {
             feedItems.forEach { feedItem ->
                 try {
+                    feedItem.accepted = DateTime.now().toDate()
                     if (feedItemDAO.add(feedItem)) {
                         rssAddedItems.increment()
                     }

--- a/src/test/java/uk/co/eelpieconsulting/feedlistener/controllers/FeedItemPopulatorTest.java
+++ b/src/test/java/uk/co/eelpieconsulting/feedlistener/controllers/FeedItemPopulatorTest.java
@@ -17,7 +17,7 @@ public class FeedItemPopulatorTest {
     @Test
     public void canCorrectForExcessivelyEscapedInputFeeds() {
         final String incorrectlyEscapedHeadline = "St John&#39;s Bar, 5 Cable Street, Te Aro, Wellington";
-        FeedItem feedItem = new FeedItem(incorrectlyEscapedHeadline, "http://localhost", null, DateTime.now().toDate(), null, null, null,
+        FeedItem feedItem = new FeedItem(incorrectlyEscapedHeadline, "http://localhost", null, DateTime.now().toDate(), null, null, null, null,
                 UUID.randomUUID().toString(), UUID.randomUUID().toString(), null);
 
         FeedItem fixed = new FeedItemPopulator(subscriptionLabelService).overlyUnescape(feedItem);

--- a/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/daos/FeedItemDAOTest.kt
+++ b/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/daos/FeedItemDAOTest.kt
@@ -119,6 +119,7 @@ class FeedItemDAOTest {
             UUID.randomUUID().toString(),
             url,
             null,
+            null,
             DateTime.now().toDate(),
             null,
             null,


### PR DESCRIPTION
RSS spec allows missing pubDates on feed items.
Accept this by making out date field optional.
Kick the item ordering problem down the road by recording an accepted timestamp on new feed items.

In the future the effective item ordering is probably some function of date and accepted date; or default to accepted with a backfill.
