### PR TITLE
Frequency classification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>30.0-jre</version>

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/controllers/ui/SubscriptionsUIController.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/controllers/ui/SubscriptionsUIController.kt
@@ -95,6 +95,7 @@ class SubscriptionsUIController @Autowired constructor(
                         .addObject("channel", channel)
                         .addObject("subscription", subscription)
                         .addObject("frequency", classifier.frequency(subscription))
+                        .addObject("fetchInterval", rssPoller.fetchIntervalFor(subscription))
                     mv
                 }
             }

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/controllers/ui/SubscriptionsUIController.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/controllers/ui/SubscriptionsUIController.kt
@@ -27,6 +27,7 @@ import uk.co.eelpieconsulting.feedlistener.model.RssSubscription
 import uk.co.eelpieconsulting.feedlistener.model.User
 import uk.co.eelpieconsulting.feedlistener.rss.RssPoller
 import uk.co.eelpieconsulting.feedlistener.rss.RssSubscriptionManager
+import uk.co.eelpieconsulting.feedlistener.rss.classification.Classifier
 
 @Controller
 class SubscriptionsUIController @Autowired constructor(
@@ -38,7 +39,8 @@ class SubscriptionsUIController @Autowired constructor(
     private val urlBuilder: UrlBuilder,
     private val conditionalLoads: ConditionalLoads,
     currentUserService: CurrentUserService,
-    request: HttpServletRequest
+    request: HttpServletRequest,
+    private val classifier: Classifier
 ) : WithSignedInUser(currentUserService, request) {
 
     private val log = LogManager.getLogger(SubscriptionsUIController::class.java)
@@ -92,6 +94,7 @@ class SubscriptionsUIController @Autowired constructor(
                     mv.addObject("user", it)
                         .addObject("channel", channel)
                         .addObject("subscription", subscription)
+                        .addObject("frequency", classifier.frequency(subscription))
                     mv
                 }
             }

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/RssSubscription.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/RssSubscription.kt
@@ -6,13 +6,14 @@ import uk.co.eelpieconsulting.feedlistener.rss.classification.FeedStatus
 
 @Entity("subscriptions")
 class RssSubscription(
-    val url: String, channelId: String, username: String, var classification: FeedStatus? = null, var classifications: Set<FeedStatus>? = emptySet()
+    val url: String, channelId: String, username: String, var classification: FeedStatus? = null, classifications: Set<FeedStatus>? = emptySet()
 ) : Subscription() {
 
     init {
         id = channelId + "-" + "feed-" + DigestUtils.md5Hex(url)
         this.channelId = channelId
         this.username =username
+        this.classifications = classifications
     }
 
 }

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/RssSubscription.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/RssSubscription.kt
@@ -6,7 +6,7 @@ import uk.co.eelpieconsulting.feedlistener.rss.classification.FeedStatus
 
 @Entity("subscriptions")
 class RssSubscription(
-    val url: String, channelId: String, username: String, var classification: FeedStatus? = null
+    val url: String, channelId: String, username: String, var classification: FeedStatus? = null, var classifications: Set<FeedStatus>? = emptySet()
 ) : Subscription() {
 
     init {

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/Subscription.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/model/Subscription.kt
@@ -7,6 +7,7 @@ import dev.morphia.annotations.Entity
 import dev.morphia.annotations.Id
 import dev.morphia.annotations.Indexed
 import org.bson.types.ObjectId
+import uk.co.eelpieconsulting.feedlistener.rss.classification.FeedStatus
 import java.util.*
 
 @Entity("subscriptions")
@@ -28,6 +29,7 @@ abstract class Subscription {
     var httpStatus: Int? = null
     var itemCount= 0L
     var lastModified: Date? = null
+    var classifications: Set<FeedStatus>? = emptySet()
 
     @Indexed
     lateinit var channelId: String

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssPoller.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssPoller.kt
@@ -18,6 +18,7 @@ import uk.co.eelpieconsulting.feedlistener.daos.FeedItemDAO
 import uk.co.eelpieconsulting.feedlistener.daos.SubscriptionsDAO
 import uk.co.eelpieconsulting.feedlistener.model.FeedItem
 import uk.co.eelpieconsulting.feedlistener.model.RssSubscription
+import uk.co.eelpieconsulting.feedlistener.model.Subscription
 import uk.co.eelpieconsulting.feedlistener.rss.classification.Classifier
 import uk.co.eelpieconsulting.feedlistener.rss.classification.FeedStatus
 import java.time.ZonedDateTime
@@ -57,6 +58,12 @@ class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO,
             ?: // If never read then read now
             return true
 
+        val readInterval = fetchIntervalFor(subscription)
+
+        return lastRead.before(DateTime.now().minus(readInterval).toDate())
+    }
+
+    fun fetchIntervalFor(subscription: Subscription): Duration? {
         val oneHour = Duration.standardHours(1)
         val oneDay = Duration.standardDays(1)
         val okHttpStatuses = setOf(FeedStatus.ok, FeedStatus.wobbling)
@@ -73,8 +80,7 @@ class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO,
             // broken and gone feeds are only read once a day to look for a potential resurrection.
             oneDay
         }
-
-        return lastRead.before(DateTime.now().minus(readInterval).toDate())
+        return readInterval
     }
 
     private fun run(subscription: RssSubscription) {

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/classification/Classifier.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/classification/Classifier.kt
@@ -1,17 +1,49 @@
 package uk.co.eelpieconsulting.feedlistener.rss.classification
 
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics
+import org.apache.logging.log4j.LogManager
 import org.joda.time.DateTime
+import org.joda.time.Duration
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import uk.co.eelpieconsulting.feedlistener.daos.FeedItemDAO
 import uk.co.eelpieconsulting.feedlistener.model.RssSubscription
+import uk.co.eelpieconsulting.feedlistener.model.Subscription
 
 @Component
-class Classifier {
+class Classifier  @Autowired constructor(private val feedItemDAO: FeedItemDAO)  {
+
+    private val log = LogManager.getLogger(Classifier::class.java)
 
     private val goodHttpCodes = setOf(200, 304)
     private val badHttpCodes = setOf(404, 401, -1)
 
     fun classify(subscription: RssSubscription): FeedStatus? {
+        val frequency = frequency(subscription)
         return livenessStatus(subscription)
+    }
+
+    fun frequency(subscription: Subscription): String? {
+        // Given a subscription estimate the frequency of posts by look at the gaps between it's previous posts
+
+        val subscriptionFeedItems = feedItemDAO.getSubscriptionFeedItems(subscription, 1, 20)
+        val feedItems = subscriptionFeedItems.feedsItems
+
+        val itemDates = feedItems.mapNotNull {
+            if (it.date != null) it.date else it.accepted
+        }
+        if (itemDates.size < 3) {
+            return null
+        }
+        val stats: DescriptiveStatistics = DescriptiveStatistics()
+
+        for (i: Int in 0 until feedItems.size - 1) {
+            val gap =  Duration(DateTime(itemDates[i + 1]), DateTime(itemDates[i])).toStandardHours().hours.toDouble()
+            stats.addValue(gap)
+        }
+        
+        log.info("Frequency stats for " + subscription.name + ": " + stats.mean + " " + stats.standardDeviation)
+        return "${stats.mean} / ${stats.standardDeviation}"
     }
 
     private fun livenessStatus(subscription: RssSubscription) =

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/classification/Classifier.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/classification/Classifier.kt
@@ -38,8 +38,8 @@ class Classifier  @Autowired constructor(private val feedItemDAO: FeedItemDAO)  
         val stats: DescriptiveStatistics = DescriptiveStatistics()
 
         for (i: Int in 0 until feedItems.size - 1) {
-            val gap =  Duration(DateTime(itemDates[i + 1]), DateTime(itemDates[i])).toStandardHours().hours.toDouble()
-            stats.addValue(gap)
+            val gapInDays =  Duration(DateTime(itemDates[i + 1]), DateTime(itemDates[i])).toStandardHours().hours.toDouble() / 24.0
+            stats.addValue(gapInDays)
         }
         
         log.info("Frequency stats for " + subscription.name + ": " + stats.mean + " " + stats.standardDeviation)

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/classification/FeedStatus.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/classification/FeedStatus.kt
@@ -1,3 +1,3 @@
 package uk.co.eelpieconsulting.feedlistener.rss.classification
 
-enum class FeedStatus {ok, broken, gone, wobbling}
+enum class FeedStatus {ok, broken, gone, wobbling, frequent}

--- a/src/main/resources/includes/classification.vm
+++ b/src/main/resources/includes/classification.vm
@@ -1,3 +1,5 @@
-#if($subscription.classification)
-    ($subscription.classification)
+#if($subscription.classifications)
+    #foreach($classification in $subscription.classifications)
+        ($classification)
+    #end
 #end

--- a/src/main/resources/subscription.vm
+++ b/src/main/resources/subscription.vm
@@ -43,7 +43,8 @@
                 #end
             #end
 
-            <p>$frequency</p>
+            <p>$!frequency</p>
+            <p>$!fetchInterval</p>
 
             #if($subscription.latestItemDate)
                 <p>Latest item date: $dateFormatter.timeSince($subscription.latestItemDate)</p>

--- a/src/main/resources/subscription.vm
+++ b/src/main/resources/subscription.vm
@@ -43,6 +43,8 @@
                 #end
             #end
 
+            <p>$frequency</p>
+
             #if($subscription.latestItemDate)
                 <p>Latest item date: $dateFormatter.timeSince($subscription.latestItemDate)</p>
             #end

--- a/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/TestData.kt
+++ b/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/TestData.kt
@@ -19,9 +19,8 @@ interface TestData {
         return subscription
     }
 
-    fun testFeedItemFor(subscription: RssSubscription, categories: List<Category>? = null): FeedItem {
+    fun testFeedItemFor(subscription: RssSubscription, categories: List<Category>? = null, date: DateTime = DateTime(2023, 5, 2, 12, 23, DateTimeZone.UTC)): FeedItem {
         val url = "http://localhost/" + UUID.randomUUID().toString()
-        val date = DateTime(2023, 5, 2, 12, 23, DateTimeZone.UTC)
         return FeedItem(
             ObjectId.get(),
             UUID.randomUUID().toString(),

--- a/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/TestData.kt
+++ b/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/TestData.kt
@@ -7,11 +7,13 @@ import uk.co.eelpieconsulting.feedlistener.model.Category
 import uk.co.eelpieconsulting.feedlistener.model.Channel
 import uk.co.eelpieconsulting.feedlistener.model.FeedItem
 import uk.co.eelpieconsulting.feedlistener.model.RssSubscription
+import uk.co.eelpieconsulting.feedlistener.rss.classification.FeedStatus
 import java.util.*
 
 interface TestData {
-    fun testSubscription(channel: Channel): RssSubscription {
-        val subscription = RssSubscription(url = "http://localhost/rss", channelId = channel.id, username = "a-user")
+
+    fun testSubscription(channel: Channel, classifications: Set<FeedStatus> = emptySet()): RssSubscription {
+        val subscription = RssSubscription(url = "http://localhost/rss", channelId = channel.id, username = "a-user", classifications = classifications)
         subscription.id = UUID.randomUUID().toString()
         subscription.channelId = channel.id
         return subscription

--- a/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/classification/ClassifierTest.kt
+++ b/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/classification/ClassifierTest.kt
@@ -74,7 +74,7 @@ class ClassifierTest {
 
         val frequency = classifier.frequency(subscription)
 
-        assertEquals("108.0 / 50.91168824543142", frequency)
+        assertEquals("4.5 / 2.1213203435596424", frequency)
     }
 
     private fun testFeedItemFor(subscription: RssSubscription, categories: List<Category>? = null): FeedItem {

--- a/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/classification/ClassifierTest.kt
+++ b/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/classification/ClassifierTest.kt
@@ -63,9 +63,9 @@ class ClassifierTest : TestData {
         subscription.httpStatus = 200
 
         val feedsItems = listOf(
-            testFeedItemFor(subscription).copy(date = DateTime.now().minusDays(1).toDate()),
-            testFeedItemFor(subscription).copy(date = DateTime.now().minusDays(7).toDate()),
-            testFeedItemFor(subscription).copy(date = DateTime.now().minusDays(10).toDate())
+            testFeedItemFor(subscription, date = DateTime.now().minusDays(1)),
+            testFeedItemFor(subscription, date = DateTime.now().minusDays(7)),
+            testFeedItemFor(subscription, date = DateTime.now().minusDays(10))
         )
 
         `when`(feedItemDAO.getSubscriptionFeedItems(subscription, 1, 20)).thenReturn(FeedItemsResult(feedsItems, feedsItems.size.toLong()))

--- a/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/classification/ClassifierTest.kt
+++ b/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/classification/ClassifierTest.kt
@@ -1,8 +1,15 @@
 package uk.co.eelpieconsulting.feedlistener.classification
 
+import org.bson.types.ObjectId
 import org.joda.time.DateTime
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import uk.co.eelpieconsulting.feedlistener.daos.FeedItemDAO
+import uk.co.eelpieconsulting.feedlistener.model.Category
+import uk.co.eelpieconsulting.feedlistener.model.FeedItem
+import uk.co.eelpieconsulting.feedlistener.model.FeedItemsResult
 import uk.co.eelpieconsulting.feedlistener.model.RssSubscription
 import uk.co.eelpieconsulting.feedlistener.rss.classification.Classifier
 import uk.co.eelpieconsulting.feedlistener.rss.classification.FeedStatus
@@ -10,13 +17,16 @@ import java.util.*
 
 class ClassifierTest {
 
-    private val classifier = Classifier()
+    private val feedItemDAO = Mockito.mock(FeedItemDAO::class.java)
+
+    private val classifier = Classifier(feedItemDAO)
 
     @Test
     fun http200WithNoErrorIsOk() {
         val subscription = RssSubscription("http://localhost/ok", UUID.randomUUID().toString(), "a-user")
         subscription.httpStatus = 200
         subscription.error = null
+        `when`(feedItemDAO.getSubscriptionFeedItems(subscription, 1, 20)).thenReturn(FeedItemsResult(emptyList(), 0L))
 
         val result = classifier.classify(subscription)
 
@@ -27,6 +37,7 @@ class ClassifierTest {
     fun http404IsGone() {
         val subscription = RssSubscription("http://localhost/gone", UUID.randomUUID().toString(), "a-user")
         subscription.httpStatus = 404
+        `when`(feedItemDAO.getSubscriptionFeedItems(subscription, 1, 20)).thenReturn(FeedItemsResult(emptyList(), 0L))
 
         val result = classifier.classify(subscription)
 
@@ -39,10 +50,49 @@ class ClassifierTest {
         val subscription = RssSubscription("http://localhost/gone", UUID.randomUUID().toString(), "a-user")
         subscription.latestItemDate = DateTime.now().minusDays(1).toDate()
         subscription.httpStatus = -1
+        `when`(feedItemDAO.getSubscriptionFeedItems(subscription, 1, 20)).thenReturn(FeedItemsResult(emptyList(), 0L))
 
         val result = classifier.classify(subscription)
 
         assertEquals(FeedStatus.wobbling, result)
     }
 
+    @Test
+    fun subscriptionWithRegularPostsShouldBeClassifiedAsFrequent() {
+        // ie. the feed reading service has lost it's own connection. We don't want a back off when reading resumes.
+        val subscription = RssSubscription("http://localhost/recent", UUID.randomUUID().toString(), "a-user")
+        subscription.latestItemDate = DateTime.now().minusDays(1).toDate()
+        subscription.httpStatus = 200
+
+        val feedsItems = listOf(
+            testFeedItemFor(subscription).copy(date = DateTime.now().minusDays(1).toDate()),
+            testFeedItemFor(subscription).copy(date = DateTime.now().minusDays(7).toDate()),
+            testFeedItemFor(subscription).copy(date = DateTime.now().minusDays(10).toDate())
+        )
+
+        `when`(feedItemDAO.getSubscriptionFeedItems(subscription, 1, 20)).thenReturn(FeedItemsResult(feedsItems, feedsItems.size.toLong()))
+
+        val frequency = classifier.frequency(subscription)
+
+        assertEquals("108.0 / 50.91168824543142", frequency)
+    }
+
+    private fun testFeedItemFor(subscription: RssSubscription, categories: List<Category>? = null): FeedItem {
+        val url = "http://localhost/" + UUID.randomUUID().toString()
+        return FeedItem(
+            ObjectId.get(),
+            UUID.randomUUID().toString(),
+            url,
+            null,
+            DateTime.now().toDate(),
+            DateTime.now().toDate(),
+            null,
+            null,
+            null,
+            subscription.id,
+            subscription.channelId,
+            categories,
+            DateTime.now().toDate()
+        )
+    }
 }

--- a/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/classification/ClassifierTest.kt
+++ b/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/classification/ClassifierTest.kt
@@ -1,21 +1,19 @@
 package uk.co.eelpieconsulting.feedlistener.classification
 
-import org.bson.types.ObjectId
 import org.joda.time.DateTime
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
+import uk.co.eelpieconsulting.feedlistener.TestData
 import uk.co.eelpieconsulting.feedlistener.daos.FeedItemDAO
-import uk.co.eelpieconsulting.feedlistener.model.Category
-import uk.co.eelpieconsulting.feedlistener.model.FeedItem
 import uk.co.eelpieconsulting.feedlistener.model.FeedItemsResult
 import uk.co.eelpieconsulting.feedlistener.model.RssSubscription
 import uk.co.eelpieconsulting.feedlistener.rss.classification.Classifier
 import uk.co.eelpieconsulting.feedlistener.rss.classification.FeedStatus
 import java.util.*
 
-class ClassifierTest {
+class ClassifierTest : TestData {
 
     private val feedItemDAO = Mockito.mock(FeedItemDAO::class.java)
 
@@ -30,7 +28,7 @@ class ClassifierTest {
 
         val result = classifier.classify(subscription)
 
-        assertEquals(FeedStatus.ok, result)
+        assertEquals(setOf(FeedStatus.ok), result)
     }
 
     @Test
@@ -41,7 +39,7 @@ class ClassifierTest {
 
         val result = classifier.classify(subscription)
 
-        assertEquals(FeedStatus.gone, result)
+        assertEquals(setOf(FeedStatus.gone), result)
     }
 
     @Test
@@ -54,7 +52,7 @@ class ClassifierTest {
 
         val result = classifier.classify(subscription)
 
-        assertEquals(FeedStatus.wobbling, result)
+        assertEquals(setOf(FeedStatus.wobbling), result)
     }
 
     @Test
@@ -74,25 +72,7 @@ class ClassifierTest {
 
         val frequency = classifier.frequency(subscription)
 
-        assertEquals("4.5 / 2.1213203435596424", frequency)
+        assertEquals(4.5, frequency!!, 0.1)
     }
 
-    private fun testFeedItemFor(subscription: RssSubscription, categories: List<Category>? = null): FeedItem {
-        val url = "http://localhost/" + UUID.randomUUID().toString()
-        return FeedItem(
-            ObjectId.get(),
-            UUID.randomUUID().toString(),
-            url,
-            null,
-            DateTime.now().toDate(),
-            DateTime.now().toDate(),
-            null,
-            null,
-            null,
-            subscription.id,
-            subscription.channelId,
-            categories,
-            DateTime.now().toDate()
-        )
-    }
 }

--- a/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/daos/SubscriptionsDAOTest.kt
+++ b/src/test/kotlin/uk/co/eelpieconsulting/feedlistener/daos/SubscriptionsDAOTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import uk.co.eelpieconsulting.feedlistener.TestData
 import uk.co.eelpieconsulting.feedlistener.model.Channel
+import uk.co.eelpieconsulting.feedlistener.rss.classification.FeedStatus
 import java.util.*
 
 class SubscriptionsDAOTest : TestData {
@@ -26,13 +27,15 @@ class SubscriptionsDAOTest : TestData {
     @Test
     fun canFetchSubscriptionByChannel() {
         val channel = Channel(ObjectId.get(), UUID.randomUUID().toString(), "A channel", "a-user")
-        val subscription = testSubscription(channel)
+        val subscription = testSubscription(channel, classifications = setOf(FeedStatus.frequent, FeedStatus.ok))
         subscriptionsDAO.add(subscription)
 
         val channelSubscriptions = subscriptionsDAO.getSubscriptionsForChannel(channel.id, null)
 
         assertEquals(1, channelSubscriptions.size)
-        assertEquals(subscription.id, channelSubscriptions.first().id)
+        val first = channelSubscriptions.first()
+        assertEquals(subscription.id, first.id)
+        assertEquals(setOf(FeedStatus.frequent, FeedStatus.ok), first.classifications)
     }
 
     @Test
@@ -45,5 +48,7 @@ class SubscriptionsDAOTest : TestData {
 
         assertNull(subscriptionsDAO.getById(subscription.id))
     }
+
+
 
 }


### PR DESCRIPTION
Introduce a 'frequent' classification based on the average gap between a feeds posts.

Use this as a signal for less frequent polling of of infrequent feeds.
Seems to save at least 1/2 on daily traffic.

<img width="1237" alt="Screenshot 2023-06-02 at 16 31 08" src="https://github.com/tonytw1/whakaoko/assets/150238/b5baa3e8-c6ba-4b2e-bba1-bccce3d2d477">
