### PR TITLE
RSS poller uses Kotlin coroutines rather than a ThreadPool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
             <version>2.3.1</version>
         </dependency>
         <dependency>
+            <groupId>com.github.kittinunf.fuel</groupId>
+            <artifactId>fuel-coroutines</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.kittinunf.result</groupId>
             <artifactId>result</artifactId>
             <version>3.1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <version>1.9.0</version>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/Main.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/Main.kt
@@ -13,9 +13,7 @@ import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.task.TaskExecutor
 import org.springframework.scheduling.annotation.EnableScheduling
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import uk.co.eelpieconsulting.common.dates.DateFormatter
@@ -50,15 +48,6 @@ open class Main : WebMvcConfigurer {
     @Bean
     open fun httpFetcher(): HttpFetcher {
         return HttpFetcher("Whakaoko/1.0", 20000)
-    }
-
-    @Bean("rssPollerTaskExecutor")
-    open fun taskExecutor(): TaskExecutor {
-        val taskExecutor = ThreadPoolTaskExecutor()
-        taskExecutor.corePoolSize = 5
-        taskExecutor.maxPoolSize = 10
-        taskExecutor.queueCapacity = 5000
-        return taskExecutor
     }
 
     @Bean

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/http/HttpFetcher.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/http/HttpFetcher.kt
@@ -3,8 +3,7 @@ package uk.co.eelpieconsulting.feedlistener.http
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Headers
 import com.github.kittinunf.fuel.core.Request
-import com.github.kittinunf.fuel.core.awaitResponseResult
-import com.github.kittinunf.fuel.core.deserializers.ByteArrayDeserializer
+import com.github.kittinunf.fuel.coroutines.awaitByteArrayResponseResult
 import com.github.kittinunf.fuel.httpGet
 import com.github.kittinunf.result.Result
 import org.apache.logging.log4j.LogManager
@@ -30,7 +29,7 @@ class HttpFetcher(private val userAgent: String, private val timeout: Int) {
             request.header("If-Modified-Since", ifModifiedSince)
         }
 
-        val (_, response, result) = request.awaitResponseResult(ByteArrayDeserializer())
+        val (_, response, result) = request.awaitByteArrayResponseResult()
         return result.fold({ bytes ->
             val httpResult = HttpResult(bytes = bytes, status = response.statusCode, headers = response.headers)
             Result.success(httpResult)

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/http/HttpFetcher.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/http/HttpFetcher.kt
@@ -3,6 +3,8 @@ package uk.co.eelpieconsulting.feedlistener.http
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Headers
 import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.awaitResponseResult
+import com.github.kittinunf.fuel.core.deserializers.ByteArrayDeserializer
 import com.github.kittinunf.fuel.httpGet
 import com.github.kittinunf.result.Result
 import org.apache.logging.log4j.LogManager
@@ -15,7 +17,7 @@ class HttpFetcher(private val userAgent: String, private val timeout: Int) {
 
     private val log = LogManager.getLogger(HttpFetcher::class.java)
 
-    fun get(url: String, etag: String?, lastModified: Date?): Result<HttpResult, FuelError> {
+    suspend fun get(url: String, etag: String?, lastModified: Date?): Result<HttpResult, FuelError> {
         val request = withCommonRequestProperties(url.httpGet())
         etag?.let {
             request.header("If-None-Match", etag)
@@ -28,7 +30,7 @@ class HttpFetcher(private val userAgent: String, private val timeout: Int) {
             request.header("If-Modified-Since", ifModifiedSince)
         }
 
-        val (_, response, result) = request.response()
+        val (_, response, result) = request.awaitResponseResult(ByteArrayDeserializer())
         return result.fold({ bytes ->
             val httpResult = HttpResult(bytes = bytes, status = response.statusCode, headers = response.headers)
             Result.success(httpResult)

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/FeedFetcher.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/FeedFetcher.kt
@@ -25,7 +25,7 @@ class FeedFetcher @Autowired constructor(private val httpFetcher: HttpFetcher,
     private val rssFetchesCounter = meterRegistry.counter("rss_fetches")
     private val rssFetchedBytesCounter = meterRegistry.counter("rss_fetched_bytes")
 
-    fun fetchFeed(subscription: RssSubscription): Result<Pair<FetchedFeed?, HttpResult>, FeedFetchingException> {
+    suspend fun fetchFeed(subscription: RssSubscription): Result<Pair<FetchedFeed?, HttpResult>, FeedFetchingException> {
         return loadSyndFeedWithFeedFetcher(subscription.url, subscription.etag, subscription.lastModified).fold({ syndFeedAndHttpResult ->
             val maybeSyndFeed = syndFeedAndHttpResult.first
             val maybeFetchedFeed = maybeSyndFeed?.let { syndFeed ->
@@ -37,7 +37,7 @@ class FeedFetcher @Autowired constructor(private val httpFetcher: HttpFetcher,
         })
     }
 
-    private fun loadSyndFeedWithFeedFetcher(feedUrl: String, etag: String?, lastModified: Date?): Result<Pair<SyndFeed?, HttpResult>, FeedFetchingException> {
+    private suspend fun loadSyndFeedWithFeedFetcher(feedUrl: String, etag: String?, lastModified: Date?): Result<Pair<SyndFeed?, HttpResult>, FeedFetchingException> {
         log.info("Loading SyndFeed from url: $feedUrl")
 
         rssFetchesCounter.increment()

--- a/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssPoller.kt
+++ b/src/main/kotlin/uk/co/eelpieconsulting/feedlistener/rss/RssPoller.kt
@@ -5,14 +5,15 @@ import com.google.common.base.Strings
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Metrics
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.newFixedThreadPoolContext
+import kotlinx.coroutines.runBlocking
 import org.apache.logging.log4j.LogManager
 import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.core.task.TaskExecutor
 import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.stereotype.Component
 import uk.co.eelpieconsulting.common.views.json.JsonSerializer
 import uk.co.eelpieconsulting.feedlistener.daos.FeedItemDAO
@@ -29,16 +30,16 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.*
-import java.util.function.Consumer
 
 @Component
-class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO,
-                                       @Qualifier("rssPollerTaskExecutor") val taskExecutor: TaskExecutor,
-                                       private val feedFetcher: FeedFetcher, val feedfItemDAO : FeedItemDAO,
-                                       val feedItemLatestDateFinder: FeedItemLatestDateFinder,
-                                       val classifier: Classifier,
-                                       val kafka: Kafka,
-                                       meterRegistry: MeterRegistry) {
+class RssPoller @Autowired constructor(
+    val subscriptionsDAO: SubscriptionsDAO,
+    private val feedFetcher: FeedFetcher, val feedItemDAO: FeedItemDAO,
+    val feedItemLatestDateFinder: FeedItemLatestDateFinder,
+    val classifier: Classifier,
+    val kafka: Kafka,
+    meterRegistry: MeterRegistry
+) {
 
     private val log = LogManager.getLogger(RssPoller::class.java)
 
@@ -46,11 +47,25 @@ class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO,
     val rssSuccessesEtagged: Counter = meterRegistry.counter("rss_successes", "etagged", "false")
     val rssSuccessesNotEtagged: Counter = meterRegistry.counter("rss_successes", "etagged", "true")
 
+    val fixedThreadPoolContext = newFixedThreadPoolContext(1, "rssPoller")
+    val limitedDispatcher = fixedThreadPoolContext.limitedParallelism(100)
+
     @Scheduled(fixedRate = 3600000, initialDelay = 300000)
     fun run() {
-        log.info("Polling subscriptions")
-        subscriptionsDAO.allRssSubscriptions().filter { shouldFetchNow(it) }.forEach(Consumer { executeRssPoll(it) })
-        log.info("Done")
+        runBlocking {
+            log.info("Polling subscriptions")
+            val start = DateTime.now()
+            subscriptionsDAO.allRssSubscriptions()
+                .filter { shouldFetchNow(it) }
+                .map { subscription ->
+                    async(limitedDispatcher) {
+                        executeRssPoll(subscription)
+                    }
+                }.awaitAll()
+
+            val duration = Duration(start, DateTime.now())
+            log.info("Done polling subscriptions in ${duration.millis}ms")
+        }
     }
 
     fun requestRead(subscription: RssSubscription) {
@@ -96,15 +111,8 @@ class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO,
     }
 
     private fun executeRssPoll(subscription: RssSubscription) {
-        val threadPoolTaskExecutor = taskExecutor as ThreadPoolTaskExecutor
-        log.info("Executing RSS poll for: " + subscription.id + " using task executor with active count: " + threadPoolTaskExecutor.activeCount + ", pool size: " + threadPoolTaskExecutor.poolSize)
-        taskExecutor.execute(ProcessFeedTask(feedFetcher, feedfItemDAO, subscriptionsDAO, subscription))
-    }
-
-    private inner class ProcessFeedTask(private val feedFetcher: FeedFetcher, private val feedItemDAO: FeedItemDAO, private val subscriptionsDAO: SubscriptionsDAO, private val subscription: RssSubscription) : Runnable {
-
-        override fun run() {
-            log.info("Processing feed: " + subscription + " from thread " + Thread.currentThread().id)
+        log.info("Processing feed: " + subscription + " from thread " + Thread.currentThread().id)
+        val start = DateTime.now()
 
             if (!hasValidUrl(subscription)) {
                 log.warn("Invalid URL: ${subscription.url}")
@@ -117,123 +125,124 @@ class RssPoller @Autowired constructor(val subscriptionsDAO: SubscriptionsDAO,
             fun pollFeed(): Result<RssSubscription, FeedFetchingException> {
                 log.info("Fetching full feed: " + subscription.url)
 
-                try {
-                    return feedFetcher.fetchFeed(subscription).fold(
-                        { successfulFetch ->
-                            val maybeFetchedFeed = successfulFetch.first
-                            val httpResult = successfulFetch.second
+            try {
+                return feedFetcher.fetchFeed(subscription).fold(
+                    { successfulFetch ->
+                        val maybeFetchedFeed = successfulFetch.first
+                        val httpResult = successfulFetch.second
 
-                            // Capture useful headers from all successful fetches
-                            subscription.error = null
-                            subscription.httpStatus = httpResult.status
+                        // Capture useful headers from all successful fetches
+                        subscription.error = null
+                        subscription.httpStatus = httpResult.status
 
-                            // Etag
-                            val etagHeader = httpResult.headers["Etag"].firstOrNull()
-                            if (!Strings.isNullOrEmpty(etagHeader)) {
-                                rssSuccessesEtagged.increment()
-                            } else {
-                                rssSuccessesNotEtagged.increment()
-                            }
-                            subscription.etag = etagHeader
-
-                            // Last-Modified
-                            val lastModifiedHeader = httpResult.headers["Last-Modified"].firstOrNull()
-                            val lastModified = lastModifiedHeader?.let {
-                                log.info("Saw last-modified header $lastModifiedHeader on url ${subscription.url}")
-                                try {
-                                    val parsed = ZonedDateTime.parse(lastModifiedHeader, DateTimeFormatter.RFC_1123_DATE_TIME)
-                                    Date.from(parsed.toInstant())
-                                } catch (dtpe: DateTimeParseException) {
-                                    log.warn("Could not parse last modified header '${lastModifiedHeader}'")
-                                    null
-                                }
-                            }
-                            subscription.lastModified = lastModified
-
-                            // If this fetch returned a full feed response then process the feed items
-                            maybeFetchedFeed?.let { fetchedFeed ->
-                                // Your fetch returned a feed. This indicates the feed has been updated or
-                                // the feed server didn't support our last modified or etag headers
-                                log.info("Fetched feed: " + fetchedFeed.feedName + " with " + fetchedFeed.feedItems.size + " feed items")
-                                persistFeedItems(fetchedFeed.feedItems)
-
-                                val itemCount = feedItemDAO.getSubscriptionFeedItemsCount(subscription.id)
-                                val latestItemDate = feedItemLatestDateFinder.getLatestItemDate(fetchedFeed.feedItems)
-
-                                // Backfill the subscription name with the feed title if not already set
-                                if (Strings.isNullOrEmpty(subscription.name)) {
-                                    subscription.name = fetchedFeed.feedName
-                                }
-                                subscription.itemCount = itemCount
-                                subscription.latestItemDate = latestItemDate
-
-                                log.info("Completed fetch of feed named '${fetchedFeed.feedName}' with ${fetchedFeed.feedItems.size} items from '${subscription.url}'. Latest feed item date was $latestItemDate")
-                                return Result.success(subscription)
-                            }
-
-                            // Our fetch return successfully but with no feed contents
-                            // This normal indicates that the feed server responded with a not modified response
-                            log.info("Feed fetch returned no feed items / HTTP ${subscription.httpStatus} for subscription: ${subscription.name}")
-                            Result.success(subscription)
-
-                        },
-                        { ex ->
-                            log.warn("Fetch feed returning error", ex)
-                            Result.error(ex)
+                        // Etag
+                        val etagHeader = httpResult.headers["Etag"].firstOrNull()
+                        if (!Strings.isNullOrEmpty(etagHeader)) {
+                            rssSuccessesEtagged.increment()
+                        } else {
+                            rssSuccessesNotEtagged.increment()
                         }
-                    )
+                        subscription.etag = etagHeader
 
-                } catch (e: Exception) {
-                    return Result.error(FeedFetchingException(e.message.toString(), null, e))
-                }
+                        // Last-Modified
+                        val lastModifiedHeader = httpResult.headers["Last-Modified"].firstOrNull()
+                        val lastModified = lastModifiedHeader?.let {
+                            log.info("Saw last-modified header $lastModifiedHeader on url ${subscription.url}")
+                            try {
+                                val parsed =
+                                    ZonedDateTime.parse(lastModifiedHeader, DateTimeFormatter.RFC_1123_DATE_TIME)
+                                Date.from(parsed.toInstant())
+                            } catch (dtpe: DateTimeParseException) {
+                                log.warn("Could not parse last modified header '${lastModifiedHeader}'")
+                                null
+                            }
+                        }
+                        subscription.lastModified = lastModified
+
+                        // If this fetch returned a full feed response then process the feed items
+                        maybeFetchedFeed?.let { fetchedFeed ->
+                            // Your fetch returned a feed. This indicates the feed has been updated or
+                            // the feed server didn't support our last modified or etag headers
+                            log.info("Fetched feed: " + fetchedFeed.feedName + " with " + fetchedFeed.feedItems.size + " feed items")
+                            persistFeedItems(fetchedFeed.feedItems)
+
+                            val itemCount = feedItemDAO.getSubscriptionFeedItemsCount(subscription.id)
+                            val latestItemDate = feedItemLatestDateFinder.getLatestItemDate(fetchedFeed.feedItems)
+
+                            // Backfill the subscription name with the feed title if not already set
+                            if (Strings.isNullOrEmpty(subscription.name)) {
+                                subscription.name = fetchedFeed.feedName
+                            }
+                            subscription.itemCount = itemCount
+                            subscription.latestItemDate = latestItemDate
+
+                            log.info("Completed fetch of feed named '${fetchedFeed.feedName}' with ${fetchedFeed.feedItems.size} items from '${subscription.url}'. Latest feed item date was $latestItemDate")
+                            return Result.success(subscription)
+                        }
+
+                        // Our fetch return successfully but with no feed contents
+                        // This normal indicates that the feed server responded with a not modified response
+                        log.info("Feed fetch returned no feed items / HTTP ${subscription.httpStatus} for subscription: ${subscription.name}")
+                        Result.success(subscription)
+
+                    },
+                    { ex ->
+                        log.warn("Fetch feed returning error", ex)
+                        Result.error(ex)
+                    }
+                )
+
+            } catch (e: Exception) {
+                return Result.error(FeedFetchingException(e.message.toString(), null, e))
             }
-
-            pollFeed().fold(
-                { updatedSubscription ->
-                    log.info("Feed polled with no errors: " + updatedSubscription.url)
-
-                }, { feedFetchingException ->
-                    val rootCauseName = feedFetchingException.rootCause?.javaClass?.simpleName.orEmpty()
-                    val httpStatus = feedFetchingException.httpStatus
-
-                    log.warn("Exception while fetching RSS subscription: " + subscription.url + ": " + rootCauseName)
-
-                    val errorMessage = feedFetchingException.message
-                    log.info("Setting feed error to: $errorMessage; http status: $httpStatus")
-                    subscription.error = errorMessage
-                    subscription.httpStatus = httpStatus
-
-                    Metrics.counter("rss_errors", "http_status", httpStatus.toString(), "exception_name", rootCauseName)
-                        .increment()
-                }
-            )
-
-            subscription.classifications = classifier.classify(subscription)
-            subscription.lastRead = DateTime.now().toDate()
-            subscriptionsDAO.save(subscription)
         }
 
-        private fun persistFeedItems(feedItems: List<FeedItem>) {
-            feedItems.forEach { feedItem ->
-                val existingSubscriptionFeeditemsWithSameUrl = feedfItemDAO.getExistingFeedItemByUrlAndSubscription(feedItem)
-                val shouldAdd = existingSubscriptionFeeditemsWithSameUrl.first() == null
-                if (shouldAdd) {
-                    val withAccepted = feedItem.copy(accepted = DateTime.now().toDate())
+        pollFeed().fold(
+            { updatedSubscription ->
+                val duration = Duration(start, DateTime.now())
+                log.info("Feed polled in ${duration.millis}ms with no errors: " + updatedSubscription.url)
 
-                    // Echo new feed items on to kafka
-                    val asJson = JsonSerializer().serialize(withAccepted)
-                    kafka.publish(asJson)
+            }, { feedFetchingException ->
+                val duration = Duration(start, DateTime.now())
+                val rootCauseName = feedFetchingException.rootCause?.javaClass?.simpleName.orEmpty()
+                log.warn("Exception after ${duration.millis}ms while fetching RSS subscription '${subscription.id}': ${subscription.url}: " + rootCauseName)
 
-                    if (feedItemDAO.add(withAccepted)) {
-                        rssAddedItems.increment()
+                val errorMessage = feedFetchingException.message
+                val httpStatus = feedFetchingException.httpStatus
+                log.info("Setting feed error to: $errorMessage; http status: $httpStatus")
+                subscription.error = errorMessage
+                subscription.httpStatus = httpStatus
 
-                    } else {
-                        log.warn("Failed to add feed item: " + feedItem.title)
-                    }
+                Metrics.counter("rss_errors", "http_status", httpStatus.toString(), "exception_name", rootCauseName)
+                    .increment()
+            }
+        )
+
+        subscription.classifications = classifier.classify(subscription)
+        subscription.lastRead = DateTime.now().toDate()
+        subscriptionsDAO.save(subscription)
+    }
+
+    private fun persistFeedItems(feedItems: List<FeedItem>) {
+        feedItems.forEach { feedItem ->
+            val existingSubscriptionFeeditemsWithSameUrl = feedItemDAO.getExistingFeedItemByUrlAndSubscription(feedItem)
+            val shouldAdd = existingSubscriptionFeeditemsWithSameUrl.first() == null
+            if (shouldAdd) {
+                val withAccepted = feedItem.copy(accepted = DateTime.now().toDate())
+
+                // Echo new feed items on to kafka
+                val asJson = JsonSerializer().serialize(withAccepted)
+                kafka.publish(asJson)
+
+                if (feedItemDAO.add(withAccepted)) {
+                    rssAddedItems.increment()
 
                 } else {
-                    log.debug("Skipping previously added: " + feedItem.title)
+                    log.warn("Failed to add feed item: " + feedItem.title)
                 }
+
+            } else {
+                log.debug("Skipping previously added: " + feedItem.title)
             }
         }
     }


### PR DESCRIPTION
Migrate from ThreadPool to coroutines.
Carefully quick that the Fuel HTTP calls we actually non blocking!

Considerable improvement in completion time for a full crawl; ~1000 feeds polled in under a minute.